### PR TITLE
fix: build on mac M1

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,13 @@ docker-compose up --detach
 ### Take it to the skies
 
 ```
-cargo run -p mav_sdk --example takeoff
+cargo run -p mav-sdk --example takeoff
 ```
 
 ### Development
 Prerequisite:
 
-1. Make sure you have SSH set for your Github account.
+1. Make sure you have SSH key set for your Github account.
 
   See Github articles:
  - [Generating a new SSH key and adding it to the ssh-agent](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ version: '3.8'
 
 services:
   px4-gazebo-headless:
+    platform: linux/amd64
     # image: jonasvautherin/px4-gazebo-headless:latest
     image: jonasvautherin/px4-gazebo-headless:1.11.0
     container_name: px4-gazebo-headless
@@ -24,6 +25,7 @@ services:
     # Proxy service from docker container using `H264`
     command: -v typhoon_h480 -w baylands
   mavsdk-grpc-server:
+    platform: linux/amd64
     build:
       dockerfile: Dockerfile-server
       context: mav-sdk

--- a/drone-book/running_a_simulation.md
+++ b/drone-book/running_a_simulation.md
@@ -33,7 +33,7 @@ For the time being, however, all you need to know is that this is how we simulat
 3. Take it to the skies
 
 ```
-cargo run -p mav_sdk --example takeoff
+cargo run -p mav-sdk --example takeoff
 ```
 
 


### PR DESCRIPTION
fixes #7

Docker will by default use platform=linux/arm64, which doesn't play well with `mavsdk_server_manylinux2010-x64`.

This commit forces platform: linux/amd64 for both `px4-gazebo-headless` and `mavsdk-grpc-server`.

I've also fixed a couple of typos while I was at it.