### PR TITLE
Migrate to use `docker compose` instead of `docker-compose`

### DIFF
--- a/drone-book/running_a_simulation.md
+++ b/drone-book/running_a_simulation.md
@@ -9,7 +9,8 @@ Operating system: Linux / MacOS(?)
 
 (?) - Currently being tested
 
-- Docker and Docker-compose for simulation (Install [Docker][install-docker] & [docker-compose][install-docker-compose])
+- Docker for simulation (Install [Docker][install-docker])
+- Docker Compose for simulation (Install [Docker Compose][install-docker-compose])
 - Rust for `cargo run` (Install the [Rust][install-rust] programming language)
 - Git
 - `ssh` key set on your GitHub profile, see [Connecting to GitHub with SSH][github-ssh]
@@ -23,11 +24,11 @@ Operating system: Linux / MacOS(?)
     1.2. `git submodule init && git submodule update`
 
 
-2. Run PX4, Gazebo and MAVSDK Server with `docker-compose`
+2. Run PX4, Gazebo and MAVSDK Server with `docker compose`
 
 
 ```
-docker-compose up --detach
+docker compose up --detach
 ```
 
 **Tools:** `PX4` (autopilot), `Gazebo` (a tool for simulations) and `MAVSDK` server are all open-source tools and later we will get to know what each tool does.


### PR DESCRIPTION
I was getting the following error:


```
Traceback (most recent call last):
  File "/usr/bin/docker-compose", line 33, in <module>
    sys.exit(load_entry_point('docker-compose==1.29.2', 'console_scripts', 'docker-compose')())
  File "/usr/lib/python3/dist-packages/compose/cli/main.py", line 81, in main
    command_func()
  File "/usr/lib/python3/dist-packages/compose/cli/main.py", line 200, in perform_command
    project = project_from_options('.', options)
  File "/usr/lib/python3/dist-packages/compose/cli/command.py", line 60, in project_from_options
    return get_project(
  File "/usr/lib/python3/dist-packages/compose/cli/command.py", line 152, in get_project
    client = get_client(
  File "/usr/lib/python3/dist-packages/compose/cli/docker_client.py", line 41, in get_client
    client = docker_client(
  File "/usr/lib/python3/dist-packages/compose/cli/docker_client.py", line 124, in docker_client
    kwargs = kwargs_from_env(environment=environment, ssl_version=tls_version)
TypeError: kwargs_from_env() got an unexpected keyword argument 'ssl_version'
```

using `docker compose up` instead, fixed that. 

